### PR TITLE
Support django-redis backend

### DIFF
--- a/docs/_static/docs.css
+++ b/docs/_static/docs.css
@@ -242,3 +242,11 @@ div.footer {
 .clearfix {
     clear: both;
 }
+
+div.admonition {
+    background-color: #fafcff;
+    border-radius: 4px;
+    color: #248;
+    border: 1.5px solid #d0e0f0;
+    padding: 1em;
+}

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -8,3 +8,4 @@ Getting Started
     usage
     hooks
     django_settings
+    supported_backends

--- a/docs/getting_started/supported_backends.rst
+++ b/docs/getting_started/supported_backends.rst
@@ -1,0 +1,33 @@
+Supported Cache Backends
+========================
+
+Built-in Django cache backends
+------------------------------
+
+* **Memcached** (``django.core.cache.backends.memcached.MemcachedCache``) - untested, but should be working.
+* **Database** (``django.core.cache.backends.db.DatabaseCache``) - tested, working.
+* **Filesystem** (``django.core.cache.backends.filebased.FileBasedCache``) - tested, working.
+* **Local memory** (``django.core.cache.backends.locmem.LocMemCache``) - tested, working.
+  But not ideal for production (see `Django docs for reasons why
+  <https://docs.djangoproject.com/en/2.1/topics/cache/#local-memory-caching>`_).
+
+.. note::
+    Wagtail Cache may or may not work correctly with 3rd party backends. If you experience an issue, please
+    `report it on our GitHub page <https://github.com/coderedcorp/wagtail-cache/issues>`_.
+
+django-redis
+------------
+
+Wagtail Cache provides a compatibility backend to support ``django-redis``. Install as follows:
+
+#. Install wagtail-cache :doc:`following the installation guide </getting_started/install>`.
+
+#. `Install django-redis <http://niwinz.github.io/django-redis/latest/#_user_guide>`_ and define
+   a Redis cache in your settings.py.
+
+#. Replace ``django_redis.cache.RedisCache`` with ``wagtailcache.compat_backends.django_redis.RedisCache``
+   in your cache definition.
+
+.. note::
+    If you are currently using Redis or have other code that uses a Redis cache, It is advised to use
+    separate cache definitions for wagtail-cache and your other uses.

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -4,5 +4,6 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    v0.3.0
     v0.2.0
     v0.1.0

--- a/docs/releases/v0.1.0.rst
+++ b/docs/releases/v0.1.0.rst
@@ -1,4 +1,4 @@
-wagtail-cache v 0.1.0 release notes
-===================================
+wagtail-cache 0.1.0 release notes
+=================================
 
 * Initial release

--- a/docs/releases/v0.2.0.rst
+++ b/docs/releases/v0.2.0.rst
@@ -1,5 +1,5 @@
-wagtail-cache v 0.2.0 release notes
-===================================
+wagtail-cache 0.2.0 release notes
+=================================
 
 * Moved ``cache_page()`` and ``clear_cache()`` from ``wagtailcache`` to ``wagtailcache.cache``.
 * New documentation! https://docs.coderedcorp.com/wagtail-cache/

--- a/docs/releases/v0.3.0.rst
+++ b/docs/releases/v0.3.0.rst
@@ -1,0 +1,6 @@
+wagtail-cache 0.3.0 release notes
+=================================
+
+* Add support for ``django-redis`` cache backend. See :doc:`/getting_started/supported_backends`.
+* Add __init__.py in templatetags directory.
+* Documentation updates.

--- a/wagtailcache/__init__.py
+++ b/wagtailcache/__init__.py
@@ -1,4 +1,4 @@
-release = ['0', '2', '0']
+release = ['0', '3', '0']
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])
 

--- a/wagtailcache/compat_backends/django_redis.py
+++ b/wagtailcache/compat_backends/django_redis.py
@@ -1,0 +1,14 @@
+from django_redis.cache import omit_exception, RedisCache as BaseBackend
+
+class RedisCache(BaseBackend):
+    """
+    Extends django_redis.cache.RedisCache for compatiblity
+    with the Django cache middleware.
+    """
+    @omit_exception
+    def set(self, *args, **kwargs):
+        """
+        Override set to return the value instead of a boolean.
+        """
+        result = super().set(*args, **kwargs)
+        return args[1]

--- a/wagtailcache/compat_backends/django_redis.py
+++ b/wagtailcache/compat_backends/django_redis.py
@@ -1,5 +1,6 @@
 from django_redis.cache import omit_exception, RedisCache as BaseBackend
 
+
 class RedisCache(BaseBackend):
     """
     Extends django_redis.cache.RedisCache for compatiblity
@@ -8,7 +9,7 @@ class RedisCache(BaseBackend):
     @omit_exception
     def set(self, *args, **kwargs):
         """
-        Override set to return the value instead of a boolean.
+        Return the value instead of a boolean.
         """
-        result = super().set(*args, **kwargs)
+        super().set(*args, **kwargs)
         return args[1]


### PR DESCRIPTION
Everything should be in order to support the django-redis cache backend. We can follow this approach going forward to support other 3rd party cache backends as needed.

Waiting for @drcongo or others to do a little more testing with their redis setups to verify it is stable and performant, before merging this in.