### PR TITLE
Adding new cache controls

### DIFF
--- a/docs/getting_started/hooks.rst
+++ b/docs/getting_started/hooks.rst
@@ -3,7 +3,7 @@ Wagtail Hooks
 
 is_request_cacheable
 --------------------
-The callable passed into this hook should take a ``request`` and a ``bool`` argument, and returns a
+The callable passed into this hook should take an ``HttpRequest`` and a ``bool`` argument, and returns a
 ``bool`` indicating whether or not the response to this request should be cached
 (served from the cache if it is already cached, or added to the cache if it is not already
 cached). Not returning, or returning anything other than a bool will not affect the caching
@@ -21,3 +21,41 @@ For example::
         # otherwise, do not return to let wagtail-cache decide how to cache.
         if 'nocache' in request.GET:
             return False
+
+
+is_response_cacheable
+---------------------
+The callable passed into this hook should take an ``HttpResponse`` and a ``bool`` argument, and returns a
+``bool`` indicating whether or not this response should be cached (added to the cache if it is not already
+cached). Not returning, or returning anything other than a bool will not affect the caching
+decision. The ``bool`` passed in represents the current caching decision. So if there were multiple
+``is_response_cacheable`` hooks called, each one would receive the result of the previous. Use this
+variable as you see fit to help with your own logic.
+
+For example::
+
+    from wagtail.core import hooks
+
+    @hooks.register('is_response_cacheable')
+    def nocache_secrets(request, curr_cache_decision):
+        # if the response contains a custom header, return False to forcibly not cache.
+        # otherwise, do not return to let wagtail-cache decide how to cache.
+        if response.has_header('X-My-Header'):
+            if response['X-My-Header'] == 'secret':
+                return False
+
+
+Notes about the request/response cycle
+--------------------------------------
+
+During a request/response cycle, wagtail-cache makes its caching decision as so:
+
+#. If the request is not a preview, does not have a logged in user, and is GET or HEAD, then try to cache.
+#. Run ``is_request_cacheable`` hooks.
+#. If the result of the hooks is ``True``, then check to see if this request is already in the cache.
+#. If the request is already in the cache, serve directly from the cache.
+#. If the request is not in the cache, then run the view.
+#. Check if the view's response contains a ``Cache-Control`` header containing ``private`` or ``no-cache``.
+#. Run ``is_response_cacheable`` hooks.
+#. If the result of the hooks is ``True``, then save the response into the cache for next time.
+#. Finally, return the response.

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -109,13 +109,13 @@ Add the mixin **to the beginning** of the class inheritance::
 
 Now ``MyPage`` will not cache if a particular instance is set to use password or login
 privacy. The ``WagtailCacheMixin`` also gives you the option to add a custom Cache-Control
-header via ``cache_control_header``, which can be a dynamic function or a string::
+header via ``cache_control``, which can be a dynamic function or a string::
 
     from wagtailcache.cache import WagtailCacheMixin
 
     class MyPage(WagtailCacheMixin, Page):
 
-        cache_control_header = 'no-cache'
+        cache_control = 'no-cache'
 
         ...
 
@@ -127,7 +127,7 @@ You could also set it to a custom value such as "public, max-age=3600". It can a
 
     class MyPage(WagtailCacheMixin, Page):
 
-        def cache_control_header(self):
+        def cache_control(self):
             return 'no-cache'
 
         ...

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -88,6 +88,54 @@ To use it on class-based views::
         ...
 
 
+4. Instruct pages how to cache (optional)
+-----------------------------------------
+
+There are many situations where a specific page should not be cached. For example,
+a page with privacy or view restrictions (e.g. password, login required), or possibly a form or
+other page with CSRF data.
+
+For that reason, it is recommended to add the ``WagtailCacheMixin`` to your Page models,
+which will handle all of these situations and provide additional control over how and when
+pages cache.
+
+Add the mixin **to the beginning** of the class inheritance::
+
+    from wagtailcache.cache import WagtailCacheMixin
+
+    class MyPage(WagtailCacheMixin, Page):
+        ...
+
+
+Now ``MyPage`` will not cache if a particular instance is set to use password or login
+privacy. The ``WagtailCacheMixin`` also gives you the option to add a custom Cache-Control
+header via ``cache_control_header``, which can be a dynamic function or a string::
+
+    from wagtailcache.cache import WagtailCacheMixin
+
+    class MyPage(WagtailCacheMixin, Page):
+
+        cache_control_header = 'no-cache'
+
+        ...
+
+
+Setting this to ``no-cache`` or ``private`` will tell wagtail-cache **not** to cache this page.
+You could also set it to a custom value such as "public, max-age=3600". It can also be a function::
+
+    from wagtailcache.cache import WagtailCacheMixin
+
+    class MyPage(WagtailCacheMixin, Page):
+
+        def cache_control_header(self):
+            return 'no-cache'
+
+        ...
+
+Regardless of the mixin, wagtail-cache will never cache a response that has a ``Cache-Control`` header
+containing ``no-cache`` or ``private``. Adding this header to any response will cause it to be skipped.
+
+
 Using a separate cache backend
 ------------------------------
 

--- a/docs/releases/v0.4.0.rst
+++ b/docs/releases/v0.4.0.rst
@@ -1,0 +1,7 @@
+wagtail-cache 0.4.0 release notes
+=================================
+
+* Added new ``is_response_cacheable`` hook. See :doc:`/getting_started/hooks`.
+* Never cache responses with a ``Cache-Control`` header containing ``no-cache`` or ``private``.
+* New ``WagtailCacheMixin`` to support Page models with privacy or view restrictions. See :doc:`/getting_started/install`.
+* Documentation updates and clarification.

--- a/wagtailcache/__init__.py
+++ b/wagtailcache/__init__.py
@@ -1,4 +1,4 @@
-release = ['0', '3', '0']
+release = ['0', '4', '0']
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])
 

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -98,14 +98,15 @@ class WagtailCacheMixin:
 
     def serve(self, request, *args, **kwargs):
         """
-        Add a cache-control header if the page is being served behind a view restriction.
+        Add a custom cache-control header, or set to private if the page is being served
+        behind a view restriction.
         """
         response = super().serve(request, *args, **kwargs)
-        if hasattr(self, 'cache_control_header'):
-            if callable(self.cache_control_header):
-                response['Cache-Control'] = self.cache_control_header()
-            else:
-                response['Cache-Control'] = self.cache_control_header
         if self.get_view_restrictions():
             response['Cache-Control'] = 'private'
+        elif hasattr(self, 'cache_control'):
+            if callable(self.cache_control):
+                response['Cache-Control'] = self.cache_control()
+            else:
+                response['Cache-Control'] = self.cache_control
         return response


### PR DESCRIPTION
* Added new mixin, which can optionally be added to a Page model to better control caching based on page privacy features or custom `cache_control_header` value on the model.

* Do not cache any response that has a `Cache-Control` header containing `no-cache` or `private`

* New `is_response_cacheable` hook.