### PR TITLE
Refactoring to provide middleware

### DIFF
--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -79,7 +79,7 @@ header via ``cache_control``, which can be a dynamic function or a string::
         ...
 
 
-Setting this to ``no-cache`` or ``private`` will tell wagtail-cache **not** to cache this page.
+Setting this to contain ``no-cache`` or ``private`` will tell wagtail-cache **not** to cache this page.
 You could also set it to a custom value such as "public, max-age=3600". It can also be a function::
 
     from wagtailcache.cache import WagtailCacheMixin
@@ -94,12 +94,33 @@ You could also set it to a custom value such as "public, max-age=3600". It can a
 Regardless of the mixin, Wagtail Cache will never cache a response that has a ``Cache-Control`` header
 containing ``no-cache`` or ``private``. Adding this header to any response will cause it to be skipped.
 
+To explicitly not cache certain views or URL patterns, you could also wrap them with the ``nocache_page``
+decorator, which adds the ``Cache-Control: no-cache`` header to all responses of that view or
+URL pattern. To use with a view::
+
+    from wagtailcache.cache import nocache_page
+
+    @nocache_page
+    def myview(request):
+        ...
+
+Or on a URL pattern::
+
+    from wagtailcache.cache import nocache_page
+
+    ...
+
+    url(r'^url/pattern/$', nocache_page(viewname), name='viewname'),
+
+    ...
+
 When using the Wagtail Cache middleware, the middleware will detect CSRF tokens and will only cache
 those responses on a per-cookie basis. So Wagtail Cache should work well with CSRF tokens 🙂.
-But if you still experience issues with CSRF tokens, use the mixin or set the ``Cache-Control`` header to
-``no-cache`` on the response to guarantee that it will never be cached. If you are using the decorator
-instead of the middleware, you **must** use the mixin or set the ``Cache-Control`` header on responses with
-CSRF tokens to avoid getting 403 forbidden errors.
+But if you still experience issues with CSRF tokens, use the mixin, the ``nocache_page`` decorator,
+or set the ``Cache-Control`` header to ``no-cache`` on the response to guarantee that it will
+never be cached. If you are using the ``cache_page`` decorator instead of the middleware, you
+**must** use the mixin or set the ``Cache-Control`` header on responses with CSRF tokens to avoid
+getting 403 forbidden errors.
 
 
 Using a separate cache backend
@@ -130,7 +151,10 @@ the page is not in preview mode, a user is not logged in, and many other require
 
 To only cache specific views, remove the middleware and use the ``cache_page`` decorator on views or URLs.
 
-Note that when using the decorator, it is not possible to cache Wagtail page 404s or redirects. Only the
+Alternatively, to continue using the middleware but explicitly not cache certain views or URLs, wrap those
+views or URLs with the ``nocache_page`` decorator.
+
+Note that when using the ``cache_page`` decorator, it is not possible to cache Wagtail page 404s or redirects. Only the
 middleware is able to cache those responses.
 
 Caching wagtail pages only

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -16,6 +16,20 @@ Add to installed apps in the project settings::
         ...
     ]
 
+Enable the middleware. ``UpdateCacheMiddleware`` must come FIRST and ``FetchFromCacheMiddleware``
+must come LAST in the list of middleware to correctly cache everything::
+
+    MIDDLEWARE = [
+        'wagtailcache.cache.UpdateCacheMiddleware',
+
+        ...
+
+        'wagtailcache.cache.FetchFromCacheMiddleware',
+    ]
+
+Do not use the Wagtail Cache middleware with the Django cache middleware. If you are currently using
+the Django cache middleware, you should remove it before adding the Wagtail Cache middleware.
+
 
 2. Define a cache
 -----------------
@@ -33,13 +47,94 @@ suitable for use on any web server::
     }
 
 
-3. Use the cache decorator
---------------------------
+3. Instruct pages how to cache (optional)
+-----------------------------------------
 
-Finally, use the ``cache_page`` decorator on any views or URLs.
+There are many situations where a specific page should not be cached. For example,
+a page with privacy or view restrictions (e.g. password, login required), or possibly a form or
+other page with CSRF data.
 
-Caching pages
-~~~~~~~~~~~~~
+For that reason, it is recommended to add the ``WagtailCacheMixin`` to your Page models,
+which will handle all of these situations and provide additional control over how and when
+pages cache.
+
+Add the mixin **to the beginning** of the class inheritance::
+
+    from wagtailcache.cache import WagtailCacheMixin
+
+    class MyPage(WagtailCacheMixin, Page):
+        ...
+
+
+Now ``MyPage`` will not cache if a particular instance is set to use password or login
+privacy. The ``WagtailCacheMixin`` also gives you the option to add a custom Cache-Control
+header via ``cache_control``, which can be a dynamic function or a string::
+
+    from wagtailcache.cache import WagtailCacheMixin
+
+    class MyPage(WagtailCacheMixin, Page):
+
+        cache_control = 'no-cache'
+
+        ...
+
+
+Setting this to ``no-cache`` or ``private`` will tell wagtail-cache **not** to cache this page.
+You could also set it to a custom value such as "public, max-age=3600". It can also be a function::
+
+    from wagtailcache.cache import WagtailCacheMixin
+
+    class MyPage(WagtailCacheMixin, Page):
+
+        def cache_control(self):
+            return 'no-cache'
+
+        ...
+
+Regardless of the mixin, Wagtail Cache will never cache a response that has a ``Cache-Control`` header
+containing ``no-cache`` or ``private``. Adding this header to any response will cause it to be skipped.
+
+When using the Wagtail Cache middleware, the middleware will detect CSRF tokens and will only cache
+those responses on a per-cookie basis. So Wagtail Cache should work well with CSRF tokens 🙂.
+But if you still experience issues with CSRF tokens, use the mixin or set the ``Cache-Control`` header to
+``no-cache`` on the response to guarantee that it will never be cached. If you are using the decorator
+instead of the middleware, you **must** use the mixin or set the ``Cache-Control`` header on responses with
+CSRF tokens to avoid getting 403 forbidden errors.
+
+
+Using a separate cache backend
+------------------------------
+
+For complex sites, it may be desirable to use a separate cache backend only for the page cache,
+so that purging the page cache will not affect other caches::
+
+    WAGTAIL_CACHE_BACKEND = 'pagecache'
+
+    CACHES = {
+        'default': {
+            ...
+        },
+        'pagecache': {
+            ...
+        }
+    }
+
+
+Only cache specific views
+-------------------------
+
+The wagtail-cache middleware will attempt to cache ALL responses that appear to be cacheable
+(meaning the response does not contain a 'no-cache'/'private' Cache-Control header, the request method
+is GET or HEAD, the response status code is 200, 301, 302, 404, the response did not set a cookie,
+the page is not in preview mode, a user is not logged in, and many other requirements).
+
+To only cache specific views, remove the middleware and use the ``cache_page`` decorator on views or URLs.
+
+Note that when using the decorator, it is not possible to cache Wagtail page 404s or redirects. Only the
+middleware is able to cache those responses.
+
+Caching wagtail pages only
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Most likely you will want this on all of your wagtail pages, so you will have to
 replace the inclusion of ``wagtail_urls`` in your project's ``urls.py``. You will
@@ -86,69 +181,3 @@ To use it on class-based views::
     @method_decorator(cache_page, name='dispatch')
     class MyView(TemplateView):
         ...
-
-
-4. Instruct pages how to cache (optional)
------------------------------------------
-
-There are many situations where a specific page should not be cached. For example,
-a page with privacy or view restrictions (e.g. password, login required), or possibly a form or
-other page with CSRF data.
-
-For that reason, it is recommended to add the ``WagtailCacheMixin`` to your Page models,
-which will handle all of these situations and provide additional control over how and when
-pages cache.
-
-Add the mixin **to the beginning** of the class inheritance::
-
-    from wagtailcache.cache import WagtailCacheMixin
-
-    class MyPage(WagtailCacheMixin, Page):
-        ...
-
-
-Now ``MyPage`` will not cache if a particular instance is set to use password or login
-privacy. The ``WagtailCacheMixin`` also gives you the option to add a custom Cache-Control
-header via ``cache_control``, which can be a dynamic function or a string::
-
-    from wagtailcache.cache import WagtailCacheMixin
-
-    class MyPage(WagtailCacheMixin, Page):
-
-        cache_control = 'no-cache'
-
-        ...
-
-
-Setting this to ``no-cache`` or ``private`` will tell wagtail-cache **not** to cache this page.
-You could also set it to a custom value such as "public, max-age=3600". It can also be a function::
-
-    from wagtailcache.cache import WagtailCacheMixin
-
-    class MyPage(WagtailCacheMixin, Page):
-
-        def cache_control(self):
-            return 'no-cache'
-
-        ...
-
-Regardless of the mixin, wagtail-cache will never cache a response that has a ``Cache-Control`` header
-containing ``no-cache`` or ``private``. Adding this header to any response will cause it to be skipped.
-
-
-Using a separate cache backend
-------------------------------
-
-For complex sites, it may be desirable to use a separate cache backend only for the page cache,
-so that purging the page cache will not affect other caches::
-
-    WAGTAIL_CACHE_BACKEND = 'pagecache'
-
-    CACHES = {
-        'default': {
-            ...
-        },
-        'pagecache': {
-            ...
-        }
-    }

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,10 +1,10 @@
 Wagtail Cache Documentation
 ===========================
 
-Wagtail Cache is a simple page cache for Wagtail using the Django cache middleware.
-It provides an extremely fast way of serving pages with no database hits whatsoever,
-but is customizable enough that the developer can determine whether or not to cache
-on a request by request basis.
+Wagtail Cache is a simple page cache for Wagtail inspired by the Django cache middleware.
+It provides an extremely fast way of serving pages with no database hits whatsoever.
+It is customizable enough that the developer can determine whether or not to cache
+on each individual request/response, or even on the Wagtail page models directly!
 
 Wagtail Cache also provides a panel to show cache stats and clear the cache
 from the wagtail admin under Settings > Cache.
@@ -14,7 +14,7 @@ Notes
 -----
 
 This cache feature was originally part of `coderedcms <https://github.com/coderedcorp/coderedcms>`_
-and has been in use successfully on live production sites.
+and is in use successfully on live production sites.
 
 Requires Wagtail >= 2.0
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    v0.5.0
     v0.4.0
     v0.3.0
     v0.2.1

--- a/docs/releases/v0.5.0.rst
+++ b/docs/releases/v0.5.0.rst
@@ -1,0 +1,9 @@
+wagtail-cache 0.5.0 release notes
+=================================
+
+* Added new middleware. This is now the recommended way of using Wagtail Cache. See :doc:`/getting_started/install`.
+* The middleware will additionally cache 404 and 301/302 responses, lightening the load on your database.
+* The middleware will intelligently handle CSRF tokens and only cache those responses based on the cookie.
+  So the new middleware should completely eliminate any CSRF token issues while also being able to cache those pages.
+* The middleware now processes all cacheable requests/responses, not just wagtail pages. To revert to previous
+  behavior, continue using the decorator.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author="CodeRed LLC",
     author_email='info@coderedcorp.com',
     url='https://github.com/coderedcorp/wagtail-cache',
-    description="A simple page cache for Wagtail using the Django cache middleware.",
+    description="A simple page cache for Wagtail based on the Django cache middleware.",
     long_description=readme,
     long_description_content_type='text/markdown',
     license="BSD license",

--- a/wagtailcache/__init__.py
+++ b/wagtailcache/__init__.py
@@ -1,4 +1,4 @@
-release = ['0', '4', '0']
+release = ['0', '5', '0']
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])
 

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -168,6 +168,22 @@ def cache_page(view_func):
     return _wrapped_view_func
 
 
+def nocache_page(view_func):
+    """
+    Decorator that sets no-cache on all responses.
+    """
+    @wraps(view_func)
+    def _wrapped_view_func(request, *args, **kwargs):
+        # Run the view.
+        response = view_func(request, *args, **kwargs)
+        # Set cache-control if wagtail-cache is enabled.
+        if wagtailcache_settings['WAGTAIL_CACHE']:
+            response['Cache-Control'] = 'no-cache'
+        return response
+
+    return _wrapped_view_func
+
+
 class WagtailCacheMixin:
     """
     Add cache-control headers to various Page responses that could be returned.

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -4,10 +4,141 @@ Functionality to set, serve from, and clear the cache.
 
 from functools import wraps
 from django.core.cache import caches
-from django.middleware.cache import CacheMiddleware
+from django.utils.cache import (
+    get_cache_key, get_max_age, has_vary_header, learn_cache_key,
+    patch_response_headers,
+)
+from django.utils.deprecation import MiddlewareMixin
 from wagtail.core import hooks
-
 from wagtailcache.settings import wagtailcache_settings
+
+
+_wagcache = caches[wagtailcache_settings['WAGTAIL_CACHE_BACKEND']]
+
+
+class FetchFromCacheMiddleware(MiddlewareMixin):
+    """
+    Loads a request from the cache if it exists.
+    Mostly stolen from `django.middleware.cache.FetchFromCacheMiddleware`.
+    """
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+
+    def process_request(self, request):
+        if not wagtailcache_settings['WAGTAIL_CACHE']:
+            return None
+
+        # Check if request is cacheable
+        # Only cache GET and HEAD requests.
+        # Don't cache requests that are previews.
+        # Don't cache reqeusts that have a logged in user.
+        request.is_preview = getattr(request, 'is_preview', False)
+        is_cacheable = \
+            request.method in ('GET', 'HEAD') and \
+            not request.is_preview and \
+            not request.user.is_authenticated
+
+        # Allow the user to override our caching decision.
+        for fn in hooks.get_hooks('is_request_cacheable'):
+            result = fn(request, is_cacheable)
+            if isinstance(result, bool):
+                is_cacheable = result
+
+        if not is_cacheable:
+            request._cache_update_cache = False
+            return None # Don't bother checking the cache.
+
+        # try and get the cached GET response
+        cache_key = get_cache_key(request, None, 'GET', cache=_wagcache)
+        if cache_key is None:
+            request._cache_update_cache = True
+            return None  # No cache information available, need to rebuild.
+        response = _wagcache.get(cache_key)
+        # if it wasn't found and we are looking for a HEAD, try looking just for that
+        if response is None and request.method == 'HEAD':
+            cache_key = get_cache_key(request, None, 'HEAD', cache=_wagcache)
+            response = _wagcache.get(cache_key)
+
+        if response is None:
+            request._cache_update_cache = True
+            return None  # No cache information available, need to rebuild.
+
+        # hit, return cached response
+        request._cache_update_cache = False
+        # Add a response header to indicate this was a cache hit
+        if wagtailcache_settings['WAGTAIL_CACHE_HEADER']:
+            response[wagtailcache_settings['WAGTAIL_CACHE_HEADER']] = 'hit'
+        return response
+
+
+class UpdateCacheMiddleware(MiddlewareMixin):
+    """
+    Saves a response to the cache.
+    Mostly stolen from `django.middleware.cache.UpdateCacheMiddleware`.
+    """
+
+    def __init__(self, get_response=None):
+        self.get_response = get_response
+
+    def _should_update_cache(self, request, response):
+        return hasattr(request, '_cache_update_cache') and request._cache_update_cache
+
+    def process_response(self, request, response):
+        if not wagtailcache_settings['WAGTAIL_CACHE']:
+            return response
+
+        if not self._should_update_cache(request, response):
+            # We don't need to update the cache, just return.
+            return response
+
+        # Check if the response is cacheable
+        # Don't cache private or no-cache responses.
+        # Do cache 200, 301, 302, 304, and 404 codes so that wagtail doesn't have to repeatedly look up these URLs in the database.
+        # Don't cache streaming responses.
+        # Don't cache responses that set a user-specific cookie in response to a cookie-less request (CSRF tokens).
+        is_cacheable = \
+            'no-cache' not in response.get('Cache-Control', ()) and \
+            'private' not in response.get('Cache-Control', ()) and \
+            response.status_code in (200, 301, 302, 304, 404) and \
+            not response.streaming and \
+            not (not request.COOKIES and response.cookies and has_vary_header(response, 'Cookie'))
+
+        # Allow the user to override our caching decision.
+        for fn in hooks.get_hooks('is_response_cacheable'):
+            result = fn(response, is_cacheable)
+            if isinstance(result, bool):
+                is_cacheable = result
+
+        # If we are not allowed to cache the response, just return.
+        if not is_cacheable:
+            # Add a response header to indicate this was intentionally not cached.
+            if wagtailcache_settings['WAGTAIL_CACHE_HEADER']:
+                response[wagtailcache_settings['WAGTAIL_CACHE_HEADER']] = 'skip'
+            return response
+
+        # Try to get the timeout from the "max-age" section of the "Cache-
+        # Control" header before reverting to using the cache's default.
+        timeout = get_max_age(response)
+        if timeout is None:
+            timeout = _wagcache.default_timeout
+        elif timeout == 0:
+            # max-age was set to 0, don't bother caching.
+            return response
+        patch_response_headers(response, timeout)
+        if timeout:
+            cache_key = learn_cache_key(request, response, timeout, None, cache=_wagcache)
+            if hasattr(response, 'render') and callable(response.render):
+                response.add_post_render_callback(
+                    lambda r: _wagcache.set(cache_key, r, timeout)
+                )
+            else:
+                _wagcache.set(cache_key, response, timeout)
+
+            # Add a response header to indicate this was a cache miss.
+            if wagtailcache_settings['WAGTAIL_CACHE_HEADER']:
+                response[wagtailcache_settings['WAGTAIL_CACHE_HEADER']] = 'miss'
+
+        return response
 
 
 def clear_cache():
@@ -15,8 +146,7 @@ def clear_cache():
     Clears the entire cache backend used by wagtail-cache.
     """
     if wagtailcache_settings['WAGTAIL_CACHE']:
-        cache = caches[wagtailcache_settings['WAGTAIL_CACHE_BACKEND']]
-        cache.clear()
+        _wagcache.clear()
 
 
 def cache_page(view_func):
@@ -25,60 +155,15 @@ def cache_page(view_func):
     """
     @wraps(view_func)
     def _wrapped_view_func(request, *args, **kwargs):
-        if wagtailcache_settings['WAGTAIL_CACHE']:
-
-            # check if request is cacheable
-            request.is_preview = getattr(request, 'is_preview', False)
-            is_cacheable = request.method in ('GET', 'HEAD') and \
-                not request.is_preview and \
-                not request.user.is_authenticated
-            for fn in hooks.get_hooks('is_request_cacheable'):
-                result = fn(request, is_cacheable)
-                if isinstance(result, bool):
-                    is_cacheable = result
-
-            if is_cacheable:
-                cache = caches[wagtailcache_settings['WAGTAIL_CACHE_BACKEND']]
-                # Create a CacheMiddleware using our specified values
-                djcache = CacheMiddleware(
-                    cache_alias=wagtailcache_settings['WAGTAIL_CACHE_BACKEND'],
-                    cache_timeout=cache.default_timeout,
-                    key_prefix=None
-                )
-                response = djcache.process_request(request)
-                if response:
-                    # add a response header to indicate this was a cache hit
-                    if wagtailcache_settings['WAGTAIL_CACHE_HEADER']:
-                        response[wagtailcache_settings['WAGTAIL_CACHE_HEADER']] = 'hit'
-                    return response
-
-                # since we don't have a response at this point, run the view.
-                response = view_func(request, *args, **kwargs)
-
-                # check if the response is cacheable
-                if response.has_header('Cache-Control'):
-                    is_cacheable = 'no-cache' not in response['Cache-Control'] and \
-                        'private' not in response['Cache-Control']
-                for fn in hooks.get_hooks('is_response_cacheable'):
-                    result = fn(response, is_cacheable)
-                    if isinstance(result, bool):
-                        is_cacheable = result
-
-                if is_cacheable:
-                    # cache the response
-                    djcache.process_response(request, response)
-                    # add a response header to indicate this was a cache miss
-                    if wagtailcache_settings['WAGTAIL_CACHE_HEADER']:
-                        response[wagtailcache_settings['WAGTAIL_CACHE_HEADER']] = 'miss'
-                else:
-                    # add a response header to indicate this was intentionally not cached
-                    if wagtailcache_settings['WAGTAIL_CACHE_HEADER']:
-                        response[wagtailcache_settings['WAGTAIL_CACHE_HEADER']] = 'skip'
-
-                return response
-
-        # as a fall-back, just run the view function.
-        return view_func(request, *args, **kwargs)
+        # Try to fetch an already cached page from wagtail-cache.
+        response = FetchFromCacheMiddleware().process_request(request)
+        if response:
+            return response
+        # Since we don't have a response at this point, process the request.
+        response = view_func(request, *args, **kwargs)
+        # Cache the response.
+        response = UpdateCacheMiddleware().process_response(request, response)
+        return response
 
     return _wrapped_view_func
 


### PR DESCRIPTION
New middleware greatly improves accuracy and performance of cache, with these two main goals:
* Cache 301, 302, and 404 responses to drastically decrease the number of database queries on sites with lots of these response codes.
* Handle CSRF tokens better to decide when/how it is appropriate to cache those without the developer having to manually set those pages to no-cache.

In order to accomplish this, we have now dumped the django cache middleware and have written our own, as the django cache middleware was too restrictive. Ours is almost an exact copy of django's, but with additional logic specific to wagtail. A nice side effect of this is that we now have full control over the cache and can use this power to implement things such as page-specific cache purging ( #2 ).