### PR TITLE
Update tests

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -29,8 +29,6 @@ stages:
       vmImage: 'ubuntu-latest'
     strategy:
       matrix:
-        py3.5:
-          PYTHON_VERSION: '3.5'
         py3.6:
           PYTHON_VERSION: '3.6'
         py3.7:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,8 @@ stages:
           PYTHON_VERSION: '3.7'
         py3.8:
           PYTHON_VERSION: '3.8'
+        py3.9:
+          PYTHON_VERSION: '3.9'
 
     steps:
     - task: UsePythonVersion@0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,7 +14,6 @@
 # import sys
 # sys.path.insert(0, os.path.abspath('.'))
 
-import os
 import datetime
 from wagtailcache import __shortversion__
 

--- a/docs/releases/index.rst
+++ b/docs/releases/index.rst
@@ -4,6 +4,7 @@ Release Notes
 .. toctree::
     :maxdepth: 1
 
+    v1.0.2
     v1.0.1
     v1.0.0
     v0.5.2

--- a/docs/releases/v1.0.2.rst
+++ b/docs/releases/v1.0.2.rst
@@ -1,0 +1,11 @@
+1.0.2 release notes
+===================
+
+* Updated ``testproject`` to work with Wagtail 2.10+
+* Removed deprecated ``wagtail.core.middleware.SiteMiddleware`` from the ``testproject``
+
+
+**Additional Notes**: ``SiteMiddleware`` was deprecated in Wagtail v.2.9 because it clashes with 
+Django's own site middleware. If this is left in your project when you upgrade
+your Wagtail versions, it will cause potential failures in this package and may 
+cause errors when running the server.

--- a/testproject/home/migrations/0002_create_homepage.py
+++ b/testproject/home/migrations/0002_create_homepage.py
@@ -15,7 +15,7 @@ def create_homepage(apps, schema_editor):
 
     # Create content type for homepage model
     homepage_content_type, __ = ContentType.objects.get_or_create(
-        model='homepage', app_label='home')
+        model='wagtailpage', app_label='home')
 
     # Create a new homepage
     homepage = WagtailPage.objects.create(

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -60,7 +60,6 @@ MIDDLEWARE = [
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'django.middleware.security.SecurityMiddleware',
 
-    'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
 
     'wagtailcache.cache.FetchFromCacheMiddleware',

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -13,8 +13,7 @@ https://docs.djangoproject.com/en/2.2/ref/settings/
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 import os
 
-PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-BASE_DIR = os.path.dirname(PROJECT_DIR)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production
@@ -73,7 +72,7 @@ TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [
-            os.path.join(PROJECT_DIR, 'templates'),
+            os.path.join(BASE_DIR, 'templates'),
         ],
         'APP_DIRS': True,
         'OPTIONS': {
@@ -121,10 +120,6 @@ USE_TZ = True
 STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-]
-
-STATICFILES_DIRS = [
-    os.path.join(PROJECT_DIR, 'static'),
 ]
 
 STATICFILES_STORAGE = 'django.contrib.staticfiles.storage.StaticFilesStorage'


### PR DESCRIPTION
Fixes #25 

- Tested each version of Wagtail from 2.9-2.12.2 
- Updated settings.py to remove legacy middleware
- Updated settings.py to change directory for local sqlite3 database
- Fixed model reference in initial homepage migration
- Project Unit Tests and testproject `runserver` now works on Wagtail 2.9+