### PR TITLE
Replaced user check with empty session query to prevent adding Vary: Cookie to requests unconditionally

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ stages:
     - script: flake8 .
       displayName: 'CR-QC: Static analysis (flake8)'
 
-    - script: black --check .
+    - script: black --diff --check .
       displayName: 'CR-QC: Format check'
 
     - script: mypy ./wagtailcache/

--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -1,8 +1,8 @@
+from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings, modify_settings
 from django.urls import reverse
 from django.utils.cache import cc_delim_re
-from django.contrib.auth.models import User
 from wagtailcache.settings import wagtailcache_settings
 from wagtailcache.cache import CacheControl, Status, clear_cache
 from wagtail.core import hooks

--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -172,15 +172,15 @@ class WagtailCacheTest(TestCase):
         return response
 
     def parse_vary_header(self, response):
-        if 'Vary' in response:
-            return {h.lower() for h in cc_delim_re.split(response['Vary'])}
+        if "Vary" in response:
+            return {h.lower() for h in cc_delim_re.split(response["Vary"])}
         return {}
 
     def should_vary_cookie(self, response):
-        self.assertIn('cookie', self.parse_vary_header(response))
+        self.assertIn("cookie", self.parse_vary_header(response))
 
     def should_not_vary_cookie(self, response):
-        self.assertNotIn('cookie', self.parse_vary_header(response))
+        self.assertNotIn("cookie", self.parse_vary_header(response))
 
     # ---- TEST PAGES ----------------------------------------------------------
 

--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -182,7 +182,6 @@ class WagtailCacheTest(TestCase):
     def should_not_vary_cookie(self, response):
         self.assertNotIn('cookie', self.parse_vary_header(response))
 
-
     # ---- TEST PAGES ----------------------------------------------------------
 
     def test_page_miss(self):

--- a/testproject/home/views.py
+++ b/testproject/home/views.py
@@ -7,6 +7,11 @@ def cached_view(request):
     return HttpResponse("Hello, World!")
 
 
+@cache_page
+def cookie_view(request):
+    return HttpResponse("Authenticated: %s" % request.user.is_authenticated)
+
+
 @nocache_page
 def nocached_view(request):
     return HttpResponse("Hello, World!")

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -13,6 +13,7 @@ urlpatterns = [
     url(r"^admin/", include(wagtailadmin_urls)),
     url(r"^documents/", include(wagtaildocs_urls)),
     url(r"^views/cached-view/", views.cached_view, name="cached_view"),
+    url(r"^views/cookie-view/", views.cookie_view, name="cookie_view"),
     url(r"^views/nocache-view/", views.nocached_view, name="nocached_view"),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -68,13 +68,16 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
         # Check if request is cacheable
         # Only cache GET and HEAD requests.
         # Don't cache requests that are previews.
-        # Don't cache requests that have a logged in user.
+        # Don't cache requests that have a logged in user
+        #    - We make use of `request.session.is_empty()` instead of
+        #      `request.user` to avoid adding `Vary: Cookie` unconditionally.
+        #      This also picks up AnonymousUsers with session data.
         # NOTE: Wagtail manually adds `is_preview` to the request object.
         #       This is not normally part of a request object.
         is_cacheable = (
             request.method in ("GET", "HEAD")
             and not getattr(request, "is_preview", False)
-            and not (hasattr(request, "user") and request.user.is_authenticated)
+            and request.session.is_empty()
         )
 
         # Allow the user to override our caching decision.

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -68,10 +68,7 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
         # Check if request is cacheable
         # Only cache GET and HEAD requests.
         # Don't cache requests that are previews.
-        # Don't cache requests that have a logged in user
-        #    - We make use of `request.session.is_empty()` instead of
-        #      `request.user` to avoid adding `Vary: Cookie` unconditionally.
-        #      This also picks up AnonymousUsers with session data.
+        # Don't cache requests with a non-empty session (refer to issue #29)
         # NOTE: Wagtail manually adds `is_preview` to the request object.
         #       This is not normally part of a request object.
         is_cacheable = (

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -67,14 +67,14 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
 
         # Check if request is cacheable
         # Only cache GET and HEAD requests.
+        # Only cache requests with an empty session (refer to issue #29)
         # Don't cache requests that are previews.
-        # Don't cache requests with a non-empty session (refer to issue #29)
         # NOTE: Wagtail manually adds `is_preview` to the request object.
         #       This is not normally part of a request object.
         is_cacheable = (
             request.method in ("GET", "HEAD")
-            and not getattr(request, "is_preview", False)
             and request.session.is_empty()
+            and not getattr(request, "is_preview", False)
         )
 
         # Allow the user to override our caching decision.


### PR DESCRIPTION
Resolves #29 by assuming non-empty sessions indicate a logged in user.  Anonymous users can have session data so this should be safer than before