### PR TITLE
Make WagtailCacheMixin not optional in docs

### DIFF
--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -47,8 +47,8 @@ suitable for use on any web server::
     }
 
 
-3. Instruct pages how to cache (optional)
------------------------------------------
+3. Instruct pages how to cache
+------------------------------
 
 There are many situations where a specific page should not be cached. For example,
 a page with privacy or view restrictions (e.g. password, login required), or possibly a form or


### PR DESCRIPTION
Section 3 of the Install docs is labelled as optional, but contains very important security-related information which should not be downplayed.

Helps address https://github.com/coderedcorp/wagtail-cache/issues/35