### PR TITLE
Strip 'Cookie' from Vary header if the Vary header contains other entries

### DIFF
--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -342,6 +342,14 @@ class WagtailCacheTest(TestCase):
         self.client.cookies["_dataminer"] = "precious data"
         self.get_hit(self.page_cachedpage.get_url())
 
+    @override_settings(WAGTAIL_CACHE_IGNORE_COOKIES=True)
+    def test_vary_header_parse(self):
+        self.get_miss(reverse("vary_view"))
+        r = self.get_hit(reverse("vary_view"))
+        # Cookie should have been stripped from the Vary header while preserving
+        # case and order of the other items.
+        self.assertEqual(r["Vary"], "A, B, C")
+
     def test_page_restricted(self):
         auth_url = "/_util/authenticate_with_password/%d/%d/" % (
             self.view_restriction.id,

--- a/testproject/home/views.py
+++ b/testproject/home/views.py
@@ -10,3 +10,9 @@ def cached_view(request):
 @nocache_page
 def nocached_view(request):
     return HttpResponse("Hello, World!")
+
+
+def vary_view(request):
+    r = HttpResponse("Variety is the spice of life.")
+    r.headers["Vary"] = "A, B, Cookie, C"
+    return r

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -12,8 +12,9 @@ urlpatterns = [
     path("django-admin/", admin.site.urls),
     path("admin/", include(wagtailadmin_urls)),
     path("documents/", include(wagtaildocs_urls)),
-    path("views/cached-view/", views.cached_view, name="cached_view"),
-    path("views/nocache-view/", views.nocached_view, name="nocached_view"),
+    path("views/cached/", views.cached_view, name="cached_view"),
+    path("views/nocache/", views.nocached_view, name="nocached_view"),
+    path("views/vary/", views.vary_view, name="vary_view"),
     # For anything not caught by a more specific rule above, hand over to
     # Wagtail's page serving mechanism. This should be the last pattern in
     # the list:

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -66,13 +66,18 @@ def _delete_vary_cookie(response: HttpResponse) -> None:
         return
     # Parse the value of Vary header.
     vary_headers = cc_delim_re.split(response.headers["Vary"])
+    # Build a lowercase-keyed dict to preserve the original case.
+    vhdict = {}
+    for item in vary_headers:
+        vhdict.update({item.lower(), item})
     # Delete "Cookie".
-    if "Cookie" in vary_headers:
-        vary_headers.remove("Cookie")
+    if "cookie" in vhdict:
+        del vhdict["cookie"]
         # Delete the header if it's empty.
-        if not vary_headers:
+        if not vhdict:
             del response.headers["Vary"]
         # Else patch the header.
+        vary_headers = [vhdict[k] for k in vhdict]
         response.headers["Vary"] = ", ".join(vary_headers)
 
 

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -73,9 +73,10 @@ def _delete_vary_cookie(response: HttpResponse) -> None:
     # Delete "Cookie".
     if "cookie" in vhdict:
         del vhdict["cookie"]
-        # Delete the header if it's empty.
+        # Delete the header if it's now empty.
         if not vhdict:
             del response.headers["Vary"]
+            return
         # Else patch the header.
         vary_headers = [vhdict[k] for k in vhdict]
         response.headers["Vary"] = ", ".join(vary_headers)

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -13,6 +13,7 @@ from django.core.handlers.wsgi import WSGIRequest
 from django.http.response import HttpResponse
 from django.template.response import SimpleTemplateResponse
 from django.utils.cache import (
+    cc_delim_re,
     get_cache_key,
     get_max_age,
     has_vary_header,
@@ -45,12 +46,34 @@ class Status(Enum):
 
 
 def _patch_header(response: HttpResponse, status: Status) -> None:
+    """
+    Adds our Cache Control status to the response headers.
+    """
     # Patch cache-control with no-cache if it is not already set.
     if status == Status.SKIP and not response.get("Cache-Control", None):
         response["Cache-Control"] = CacheControl.NOCACHE.value
     # Add our custom header.
     if wagtailcache_settings.WAGTAIL_CACHE_HEADER:
         response[wagtailcache_settings.WAGTAIL_CACHE_HEADER] = status.value
+
+
+def _delete_vary_cookie(response: HttpResponse) -> None:
+    """
+    Deletes the ``Vary: Cookie`` header while keeping other items of the
+    Vary header in tact. Inspired by ``django.utils.cache.patch_vary_headers``.
+    """
+    if not response.has_header("Vary"):
+        return
+    # Parse the value of Vary header.
+    vary_headers = cc_delim_re.split(response.headers["Vary"])
+    # Delete "Cookie".
+    if "Cookie" in vary_headers:
+        vary_headers.remove("Cookie")
+        # Delete the header if it's empty.
+        if not vary_headers:
+            del response.headers["Vary"]
+        # Else patch the header.
+        response.headers["Vary"] = ", ".join(vary_headers)
 
 
 def _chop_querystring(r: WSGIRequest) -> WSGIRequest:
@@ -103,7 +126,7 @@ def _chop_response_vary(r: WSGIRequest, s: HttpResponse) -> HttpResponse:
     if (
         not s.has_header("Set-Cookie")
         and s.has_header("Vary")
-        and s["Vary"].lower() == "cookie"
+        and has_vary_header(s, "Cookie")
         and not (
             settings.CSRF_COOKIE_NAME in s.cookies
             or settings.CSRF_COOKIE_NAME in r.COOKIES
@@ -111,7 +134,7 @@ def _chop_response_vary(r: WSGIRequest, s: HttpResponse) -> HttpResponse:
             or settings.SESSION_COOKIE_NAME in r.COOKIES
         )
     ):
-        del s["Vary"]
+        _delete_vary_cookie(s)
     return s
 
 

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -65,21 +65,21 @@ def _delete_vary_cookie(response: HttpResponse) -> None:
     if not response.has_header("Vary"):
         return
     # Parse the value of Vary header.
-    vary_headers = cc_delim_re.split(response.headers["Vary"])
+    vary_headers = cc_delim_re.split(response["Vary"])
     # Build a lowercase-keyed dict to preserve the original case.
     vhdict = {}
     for item in vary_headers:
-        vhdict.update({item.lower(), item})
+        vhdict.update({item.lower(): item})
     # Delete "Cookie".
     if "cookie" in vhdict:
         del vhdict["cookie"]
         # Delete the header if it's now empty.
         if not vhdict:
-            del response.headers["Vary"]
+            del response["Vary"]
             return
         # Else patch the header.
         vary_headers = [vhdict[k] for k in vhdict]
-        response.headers["Vary"] = ", ".join(vary_headers)
+        response["Vary"] = ", ".join(vary_headers)
 
 
 def _chop_querystring(r: WSGIRequest) -> WSGIRequest:


### PR DESCRIPTION
The feature to strip cookies will not be triggered if the Vary header contains something other than "Cookie", e.g. `Vary: Language, Cookie`. This change properly inspects and rebuilds the Vary header in such cases.