### PR TITLE
Allow compatibility with Wagtail 4.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["wagtail>=3.0,<4.0"],
+    install_requires=["wagtail>=3.0,<=4.0"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["wagtail>=3.0,<5.0"],
+    install_requires=["wagtail>=3.0,<5.0", "django>=3.0,<4.1"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["wagtail>=3.0,<=4.0"],
+    install_requires=["wagtail>=3.0,<=4.1"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["wagtail>=3.0,<=4.1"],
+    install_requires=["wagtail>=3.0,<5.0"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
@@ -27,5 +27,6 @@ setup(
         "Framework :: Django",
         "Framework :: Wagtail",
         "Framework :: Wagtail :: 3",
+        "Framework :: Wagtail :: 4",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["wagtail>=3.0,<5.0", "django>=3.0,<4.1"],
+    install_requires=["wagtail>=3.0,<5.0"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/wagtailcache/__init__.py
+++ b/wagtailcache/__init__.py
@@ -1,3 +1,3 @@
-release = ["2", "1", "2"]
+release = ["2", "1", "3"]
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])

--- a/wagtailcache/__init__.py
+++ b/wagtailcache/__init__.py
@@ -1,3 +1,3 @@
-release = ["2", "1", "1"]
+release = ["2", "1", "2"]
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -179,6 +179,7 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):
         self._wagcache = caches[wagtailcache_settings.WAGTAIL_CACHE_BACKEND]
         self.get_response = get_response
+        self._async_check()
 
     def process_request(self, request: WSGIRequest) -> Optional[HttpResponse]:
         if not wagtailcache_settings.WAGTAIL_CACHE:
@@ -233,6 +234,7 @@ class UpdateCacheMiddleware(MiddlewareMixin):
     def __init__(self, get_response=None):
         self._wagcache = caches[wagtailcache_settings.WAGTAIL_CACHE_BACKEND]
         self.get_response = get_response
+        self._async_check()
 
     def process_response(
         self, request: WSGIRequest, response: HttpResponse


### PR DESCRIPTION
The current version 2.1.1 works well with Wagtail 4, except for configuration which disallows W4.
Suggested changes:

Bumped version to 2.1.2.
Changed requirements to Wagtail <=4.0