### PR TITLE
Wagtail 5 compatibility 

### DIFF
--- a/docs/getting_started/hooks.rst
+++ b/docs/getting_started/hooks.rst
@@ -27,7 +27,7 @@ For example:
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register("is_request_cacheable")
     def nocache_in_query(request, curr_cache_decision):
@@ -54,7 +54,7 @@ For example:
 
 .. code-block:: python
 
-    from wagtail.core import hooks
+    from wagtail import hooks
 
     @hooks.register("is_response_cacheable")
     def nocache_secrets(response, curr_cache_decision):

--- a/docs/getting_started/install.rst
+++ b/docs/getting_started/install.rst
@@ -200,11 +200,11 @@ To this:
     from django.conf.urls import url
 
     from django.contrib.auth import views as auth_views
-    from wagtail.core.urls import serve_pattern, WAGTAIL_FRONTEND_LOGIN_TEMPLATE
-    from wagtail.core import views as wagtail_views
+    from wagtail.urls import serve_pattern, WAGTAIL_FRONTEND_LOGIN_TEMPLATE
+    from wagtail import views as wagtail_views
     from wagtailcache.cache import cache_page
 
-    # Copied from wagtail.core.urls:
+    # Copied from wagtail.urls:
     url(r'^_util/authenticate_with_password/(\d+)/(\d+)/$', wagtail_views.authenticate_with_password,
         name='wagtailcore_authenticate_with_password'),
     url(r'^_util/login/$', auth_views.LoginView.as_view(template_name=WAGTAIL_FRONTEND_LOGIN_TEMPLATE),

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 from wagtailcache import __version__
 
 with open("README.md", encoding="utf8") as readme_file:
@@ -16,7 +16,7 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["wagtail>=3.0,<5.0"],
+    install_requires=["wagtail>=3.0,<5.1"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     license="BSD license",
     include_package_data=True,
     packages=find_packages(),
-    install_requires=["wagtail>=3.0,<5.1"],
+    install_requires=["wagtail>=3.0,<6"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",

--- a/wagtailcache/__init__.py
+++ b/wagtailcache/__init__.py
@@ -1,3 +1,3 @@
-release = ["2", "2", "0"]
+release = ["2", "2", "1"]
 __version__ = "{0}.{1}.{2}".format(release[0], release[1], release[2])
 __shortversion__ = "{0}.{1}".format(release[0], release[1])

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -4,25 +4,20 @@ Functionality to set, serve from, and clear the cache.
 import re
 from enum import Enum
 from functools import wraps
-from typing import Callable, Optional, List
+from typing import Callable, List, Optional
 from urllib.parse import unquote
+
 from django.conf import settings
 from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
 from django.core.handlers.wsgi import WSGIRequest
 from django.http.response import HttpResponse
 from django.template.response import SimpleTemplateResponse
-from django.utils.cache import (
-    cc_delim_re,
-    get_cache_key,
-    get_max_age,
-    has_vary_header,
-    learn_cache_key,
-    patch_response_headers,
-)
+from django.utils.cache import (cc_delim_re, get_cache_key, get_max_age,
+                                has_vary_header, learn_cache_key,
+                                patch_response_headers)
 from django.utils.deprecation import MiddlewareMixin
 from wagtail import hooks
-
 from wagtailcache.settings import wagtailcache_settings
 
 
@@ -334,7 +329,7 @@ class UpdateCacheMiddleware(MiddlewareMixin):
         return response
 
 
-def clear_cache(urls: List[str] = None) -> None:
+def clear_cache(urls: List[str] = []) -> None:
     """
     Clears the Wagtail cache backend.
 


### PR DESCRIPTION
This adds support for Wagtail 5 by removing deprecated paths, namely `wagtail.core.hooks` (now `wagtail.hooks`) and `wagtail.core.urls` (now `wagtail.urls`). Documentation has also been updated.

Tests raised an error on `NoneType` as default for the `urls: List[str]` arg of `clear_cache` so I resolved that too.