### PR TITLE
Update ignored query parameters for Google Analytics

### DIFF
--- a/wagtailcache/settings.py
+++ b/wagtailcache/settings.py
@@ -14,6 +14,7 @@ class _DefaultSettings:
     WAGTAIL_CACHE_IGNORE_QS = [
         r"^_bta_.*$",  # Bronto
         r"^_ga$",  # Google Analytics
+        r"^_gl$",  # Google Analytics
         r"^affiliate$",  # Instagram affiliates
         r"^ck_subscriber_id$",  # Instagram affiliates
         r"^dm_i$",  # Dotdigital


### PR DESCRIPTION
The `_gl` parameter is used for cross-domain measurement.

https://support.google.com/analytics/answer/10071811