### PR TITLE
Prevent duplicate entries in uri_keys lists

### DIFF
--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -1,3 +1,5 @@
+import time
+
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import caches
@@ -489,6 +491,23 @@ class WagtailCacheTest(TestCase):
         url = "http://%s%s" % ("testserver", self.page_cachedpage.get_url())
         # Compare Keys
         self.assertEqual(key, url)
+
+    @override_settings(WAGTAIL_CACHE_BACKEND="one_second")
+    def test_cache_keyring_no_uri_key_duplication(self):
+        # First get to populate keyring
+        self.get_miss(self.page_cachedpage.get_url())
+        # Wait a short time
+        time.sleep(0.5)
+        # Fetch a different page
+        self.get_miss(self.page_wagtailpage.get_url())
+        # Wait until the first page is expired, but not the keyring
+        time.sleep(0.6)
+        # Fetch the first page again
+        self.get_miss(self.page_cachedpage.get_url())
+        # Check the keyring does not contain duplicate uri_keys
+        url = "http://%s%s" % ("testserver", self.page_cachedpage.get_url())
+        keyring = self.cache.get("keyring")
+        self.assertEqual(len(keyring.get(url, [])), 1)
 
     def test_clear_cache(self):
         # First get should miss cache.

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -125,6 +125,10 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "TIMEOUT": 90061,  # 1 day, 1 hour, 1 minute, 1 second.
     },
+    "one_second": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "TIMEOUT": 1,
+    },
     "zero": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "TIMEOUT": 0,

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -307,9 +307,10 @@ class UpdateCacheMiddleware(MiddlewareMixin):
             # Get current cache keys belonging to this URI.
             # This should be a list of keys.
             uri_keys: List[str] = keyring.get(uri, [])
-            # Append the key to this list and save.
-            uri_keys.append(cache_key)
-            keyring[uri] = uri_keys
+            # Append the key to this list if not already present and save.
+            if cache_key not in uri_keys:
+                uri_keys.append(cache_key)
+                keyring[uri] = uri_keys
             self._wagcache.set("keyring", keyring)
 
             if isinstance(response, SimpleTemplateResponse):


### PR DESCRIPTION
This prevents duplicate entries in the `uri_keys` lists for the items in the keyring. 