### PR TITLE
fix:  MiddlewareMixin  `_async_check()`  was  removed in django 5.1

### DIFF
--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -16,6 +16,7 @@ from django.core.cache import caches
 from django.core.cache.backends.base import BaseCache
 from django.core.handlers.wsgi import WSGIRequest
 from django.http.response import HttpResponse
+from django.http.request import HttpRequest
 from django.template.response import SimpleTemplateResponse
 from django.utils.cache import cc_delim_re
 from django.utils.cache import get_cache_key
@@ -23,7 +24,7 @@ from django.utils.cache import get_max_age
 from django.utils.cache import has_vary_header
 from django.utils.cache import learn_cache_key
 from django.utils.cache import patch_response_headers
-from django.utils.deprecation import MiddlewareMixin
+from django.utils.deprecation import GetResponseCallable, MiddlewareMixin
 from wagtail import hooks
 
 from wagtailcache.settings import wagtailcache_settings
@@ -34,6 +35,11 @@ logger = logging.getLogger("wagtail-cache")
 
 
 class MiddlewareMixinFixed(MiddlewareMixin):
+    def __init__(
+        self, get_response: Callable[[HttpRequest], HttpResponse] | None = ...
+    ) -> None:
+        super().__init__(get_response)
+
     def _async_check(self):
         """
         If get_response is a coroutine function, turns us into async mode so

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -184,7 +184,8 @@ class FetchFromCacheMiddleware(MiddlewareMixin):
     """
 
     def __init__(self, get_response=None):
-        super().__init__(get_response)
+        if get_response:
+            super().__init__(get_response)
         self._wagcache = caches[wagtailcache_settings.WAGTAIL_CACHE_BACKEND]
         self.get_response = get_response
 
@@ -251,7 +252,8 @@ class UpdateCacheMiddleware(MiddlewareMixin):
     """
 
     def __init__(self, get_response=None):
-        super().__init__(get_response)
+        if get_response:
+            super().__init__(get_response)
         self._wagcache = caches[wagtailcache_settings.WAGTAIL_CACHE_BACKEND]
         self.get_response = get_response
 


### PR DESCRIPTION
As found in #74. The  `MiddlewareMixin`  class function   `_async_check()`was removed with release of Django 5.1
see https://github.com/django/django/commit/e2922b0d5f18169d1d0115a6db5d2ed8c42d0692.

Each class inheriting from MiddlewareMixin must call super().__init__ that does the async checks and configuration for async calls

I have not tested extensively, but sofar:
✅ codered cms project startsup  without failures, 
✅Web browsing is producing no errors
✅Unit tests are all failing with get_response as None ( trapped in MiddlewareMixin __init__  https://github.com/django/django/blob/df236b0bcbbf1f54dfe6acc7761cd81b76ebf2cc/django/utils/deprecation.py#L100)

