### PR TITLE
Chop non-django cookies even if CSRF cookie or session cookie is present

### DIFF
--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -410,14 +410,14 @@ class WagtailCacheTest(TestCase):
         # First get should skip cache, and also be set to private.
         response = self.get_skip(self.page_cachedpage_restricted.get_url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get("Cache-Control", None), CacheControl.PRIVATE.value
+        self.assertIn(
+            CacheControl.PRIVATE.value, response.get("Cache-Control", None)
         )
         # Second get should continue to skip and also be set to private.
         response = self.get_skip(self.page_cachedpage_restricted.get_url())
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(
-            response.get("Cache-Control", None), CacheControl.PRIVATE.value
+        self.assertIn(
+            CacheControl.PRIVATE.value, response.get("Cache-Control", None)
         )
 
     def test_page_404(self):

--- a/testproject/home/tests.py
+++ b/testproject/home/tests.py
@@ -377,7 +377,9 @@ class WagtailCacheTest(TestCase):
         # Third request should still hit from the cache, regardless of new cookie
         response = self.get_hit(self.page_cachedpage.get_url())
         # But request should still keep the CSRF Cookie
-        self.assertTrue(settings.CSRF_COOKIE_NAME in response.wsgi_request.COOKIES)
+        self.assertTrue(
+            settings.CSRF_COOKIE_NAME in response.wsgi_request.COOKIES
+        )
         # But no other cookies
         self.assertEqual(1, len(response.wsgi_request.COOKIES))
         # Next add another tracking cookie and check that we still get a hit

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -116,10 +116,15 @@ def _chop_cookies(r: WSGIRequest) -> WSGIRequest:
     if not wagtailcache_settings.WAGTAIL_CACHE_IGNORE_COOKIES:
         return r
 
-    r.COOKIES = {k: v for k, v in r.COOKIES.items() if k in {
-        settings.CSRF_COOKIE_NAME,
-        settings.SESSION_COOKIE_NAME,
-    }}
+    r.COOKIES = {
+        k: v
+        for k, v in r.COOKIES.items()
+        if k
+        in {
+            settings.CSRF_COOKIE_NAME,
+            settings.SESSION_COOKIE_NAME,
+        }
+    }
     r.META["HTTP_COOKIE"] = "; ".join(f"{k}={v}" for k, v in r.COOKIES.items())
     return r
 

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -116,11 +116,11 @@ def _chop_cookies(r: WSGIRequest) -> WSGIRequest:
     if not wagtailcache_settings.WAGTAIL_CACHE_IGNORE_COOKIES:
         return r
 
-    if r.COOKIES and not (
-        settings.CSRF_COOKIE_NAME in r.COOKIES
-        or settings.SESSION_COOKIE_NAME in r.COOKIES
-    ):
-        r.COOKIES = {}
+    r.COOKIES = {k: v for k, v in r.COOKIES.items() if k in {
+        settings.CSRF_COOKIE_NAME,
+        settings.SESSION_COOKIE_NAME,
+    }}
+    r.META["HTTP_COOKIE"] = "; ".join(f"{k}={v}" for k, v in r.COOKIES.items())
     return r
 
 

--- a/wagtailcache/cache.py
+++ b/wagtailcache/cache.py
@@ -116,16 +116,17 @@ def _chop_cookies(r: WSGIRequest) -> WSGIRequest:
     if not wagtailcache_settings.WAGTAIL_CACHE_IGNORE_COOKIES:
         return r
 
-    r.COOKIES = {
-        k: v
-        for k, v in r.COOKIES.items()
-        if k
-        in {
+    chopped_cookies = {}
+    meta_cookies = []
+    for k, v in r.COOKIES.items():
+        if k in {
             settings.CSRF_COOKIE_NAME,
             settings.SESSION_COOKIE_NAME,
-        }
-    }
-    r.META["HTTP_COOKIE"] = "; ".join(f"{k}={v}" for k, v in r.COOKIES.items())
+        }:
+            chopped_cookies[k] = v
+            meta_cookies.append(f"{k}={v}")
+    r.COOKIES = chopped_cookies
+    r.META["HTTP_COOKIE"] = "; ".join(meta_cookies)
     return r
 
 


### PR DESCRIPTION
This PR addresses #84 
(+ I switched order of arguments in test asserts to get correct messages)