### PR TITLE
Wagtail 7.0 Maintenance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,9 +21,10 @@ classifiers = [
     "Framework :: Wagtail :: 4",
     "Framework :: Wagtail :: 5",
     "Framework :: Wagtail :: 6",
+    "Framework :: Wagtail :: 7",
 ]
 dependencies = [
-    "wagtail>=3.0,<7",
+    "wagtail>=3.0,<7.1",
 ]
 description = "A simple page cache for Wagtail based on the Django cache middleware."
 dynamic = ["version"]


### PR DESCRIPTION
### Updates to Wagtail compatibility:

* Added support for Wagtail 7 in the `classifiers` section of `pyproject.toml`.
* Updated the Wagtail dependency range to include versions up to but not including 7.1 in `pyproject.toml`.